### PR TITLE
session: support custom read and write logic for session ID

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -8,11 +8,10 @@ import (
 	"context"
 	"crypto/rand"
 	"math/big"
+	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
-
-	"github.com/flamego/flamego"
 )
 
 // Store is a session store with capabilities of checking, reading, destroying
@@ -119,10 +118,9 @@ func isValidSessionID(sid string, idLength int) bool {
 // named cookie. If a session with the ID does not exist, it creates a new
 // session with the same ID. A boolean value is returned to indicate whether a
 // new session is created.
-func (m *manager) load(c flamego.Context, cookieName string, idLength int) (_ Session, created bool, err error) {
-	sid := c.Cookie(cookieName)
-	if isValidSessionID(sid, idLength) && m.store.Exist(c.Request().Context(), sid) {
-		sess, err := m.store.Read(c.Request().Context(), sid)
+func (m *manager) load(r *http.Request, sid string, idLength int) (_ Session, created bool, err error) {
+	if isValidSessionID(sid, idLength) && m.store.Exist(r.Context(), sid) {
+		sess, err := m.store.Read(r.Context(), sid)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "read")
 		}
@@ -134,7 +132,7 @@ func (m *manager) load(c flamego.Context, cookieName string, idLength int) (_ Se
 		return nil, false, errors.Wrap(err, "new ID")
 	}
 
-	sess, err := m.store.Read(c.Request().Context(), sid)
+	sess, err := m.store.Read(r.Context(), sid)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "read")
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -36,7 +36,7 @@ func TestSessioner(t *testing.T) {
 
 	// Make a request again using the same session ID
 	resp = httptest.NewRecorder()
-	req, err = http.NewRequest("GET", "/", nil)
+	req, err = http.NewRequest(http.MethodGet, "/", nil)
 	assert.Nil(t, err)
 
 	req.Header.Set("Cookie", cookie)
@@ -67,7 +67,7 @@ func TestSessioner_Header(t *testing.T) {
 	})
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	assert.Nil(t, err)
 
 	f.ServeHTTP(resp, req)
@@ -77,7 +77,7 @@ func TestSessioner_Header(t *testing.T) {
 
 	// Make a request again using the same session ID
 	resp = httptest.NewRecorder()
-	req, err = http.NewRequest("GET", "/", nil)
+	req, err = http.NewRequest(http.MethodGet, "/", nil)
 	assert.Nil(t, err)
 
 	req.Header.Set("Session-Id", sid)

--- a/session_test.go
+++ b/session_test.go
@@ -31,5 +31,57 @@ func TestSessioner(t *testing.T) {
 	f.ServeHTTP(resp, req)
 
 	want := fmt.Sprintf("flamego_session=%s; Path=/; HttpOnly; SameSite=Lax", resp.Body.String())
-	assert.Equal(t, want, resp.Header().Get("Set-Cookie"))
+	cookie := resp.Header().Get("Set-Cookie")
+	assert.Equal(t, want, cookie)
+
+	// Make a request again using the same session ID
+	resp = httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "/", nil)
+	assert.Nil(t, err)
+
+	req.Header.Set("Cookie", cookie)
+	f.ServeHTTP(resp, req)
+
+	got := fmt.Sprintf("flamego_session=%s; Path=/; HttpOnly; SameSite=Lax", resp.Body.String())
+	assert.Equal(t, cookie, got)
+}
+
+func TestSessioner_Header(t *testing.T) {
+	f := flamego.NewWithLogger(&bytes.Buffer{})
+	f.Use(Sessioner(
+		Options{
+			ReadIDFunc: func(r *http.Request) string {
+				return r.Header.Get("Session-Id")
+			},
+			WriteIDFunc: func(w http.ResponseWriter, r *http.Request, sid string, created bool) {
+				if created {
+					r.Header.Set("Session-Id", sid)
+				}
+				w.Header().Set("Session-Id", sid)
+			},
+		},
+	))
+	f.Get("/", func(c flamego.Context, session Session, store Store) string {
+		_ = store.GC(c.Request().Context())
+		return session.ID()
+	})
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.Nil(t, err)
+
+	f.ServeHTTP(resp, req)
+
+	sid := resp.Header().Get("Session-Id")
+	assert.Equal(t, resp.Body.String(), sid)
+
+	// Make a request again using the same session ID
+	resp = httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "/", nil)
+	assert.Nil(t, err)
+
+	req.Header.Set("Session-Id", sid)
+	f.ServeHTTP(resp, req)
+
+	assert.Equal(t, sid, resp.Body.String())
 }


### PR DESCRIPTION
Please see the test file for an example of read/write session ID using a HTTP header instead of cookie.