### PR TITLE
ci: add Go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.16.x, 1.17.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -55,7 +55,7 @@ jobs:
     name: Postgres
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.16.x, 1.17.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     services:
@@ -95,7 +95,7 @@ jobs:
     name: Redis
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.16.x, 1.17.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     services:
@@ -130,7 +130,7 @@ jobs:
     name: MySQL
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.16.x, 1.17.x ]
         platform: [ ubuntu-18.04 ]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Updates CI to include Go 1.17

[_Created by Sourcegraph batch change `joe/add-go-1.17-to-flamego-ci`._](https://sourcegraph.test:3443/users/joe/batch-changes/add-go-1.17-to-flamego-ci)