### PR TITLE
feat: init table in mysql and postgres

### DIFF
--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -51,20 +51,6 @@ func newTestDB(t *testing.T, ctx context.Context) (testDB *sql.DB, cleanup func(
 		t.Fatalf("Failed to open test database: %v", err)
 	}
 
-	q := fmt.Sprintf(`
-CREATE TABLE sessions (
-	%[1]s      VARCHAR(255) NOT NULL,
-	data       BLOB NOT NULL,
-	expired_at DATETIME NOT NULL,
-	PRIMARY KEY (%[1]s)
-) DEFAULT CHARSET=utf8`,
-		quoteWithBackticks("key"),
-	)
-	_, err = testDB.ExecContext(ctx, q)
-	if err != nil {
-		t.Fatalf("Failed to create sessions table: %v", err)
-	}
-
 	t.Cleanup(func() {
 		defer func() { _ = db.Close() }()
 
@@ -108,8 +94,9 @@ func TestMySQLStore(t *testing.T) {
 		session.Options{
 			Initer: Initer(),
 			Config: Config{
-				nowFunc: time.Now,
-				db:      db,
+				nowFunc:   time.Now,
+				db:        db,
+				InitTable: true,
 			},
 		},
 	))
@@ -174,9 +161,10 @@ func TestMySQLStore_GC(t *testing.T) {
 	now := time.Now()
 	store, err := Initer()(ctx,
 		Config{
-			nowFunc:  func() time.Time { return now },
-			db:       db,
-			Lifetime: time.Second,
+			nowFunc:   func() time.Time { return now },
+			db:        db,
+			Lifetime:  time.Second,
+			InitTable: true,
 		},
 	)
 	assert.Nil(t, err)

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -66,17 +66,6 @@ func newTestDB(t *testing.T, ctx context.Context) (testDB *sql.DB, cleanup func(
 
 	testDB = stdlib.OpenDB(*connConfig)
 
-	q := `
-CREATE TABLE sessions (
-    key        TEXT PRIMARY KEY,
-    data       BYTEA NOT NULL,
-    expired_at TIMESTAMP WITH TIME ZONE NOT NULL
-)`
-	_, err = testDB.ExecContext(ctx, q)
-	if err != nil {
-		t.Fatalf("Failed to create sessions table: %v", err)
-	}
-
 	t.Cleanup(func() {
 		defer func() { _ = db.Close() }()
 
@@ -120,8 +109,9 @@ func TestPostgresStore(t *testing.T) {
 		session.Options{
 			Initer: Initer(),
 			Config: Config{
-				nowFunc: time.Now,
-				db:      db,
+				nowFunc:   time.Now,
+				db:        db,
+				InitTable: true,
 			},
 		},
 	))
@@ -186,9 +176,10 @@ func TestPostgresStore_GC(t *testing.T) {
 	now := time.Now()
 	store, err := Initer()(ctx,
 		Config{
-			nowFunc:  func() time.Time { return now },
-			db:       db,
-			Lifetime: time.Second,
+			nowFunc:   func() time.Time { return now },
+			db:        db,
+			Lifetime:  time.Second,
+			InitTable: true,
 		},
 	)
 	assert.Nil(t, err)


### PR DESCRIPTION
### Describe the pull request

Add `InitTable` flag in `Config` to determines whether create a default session table while initializing.

Link to the issue: https://github.com/flamego/flamego/issues/81

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
