### PR TITLE
load: ignore context cancel error

### DIFF
--- a/session.go
+++ b/session.go
@@ -172,6 +172,10 @@ func Sessioner(opts ...Options) flamego.Handler {
 		sid := opt.ReadIDFunc(c.Request().Request)
 		sess, created, err := mgr.load(c.Request().Request, sid, opt.IDLength)
 		if err != nil {
+			if errors.Cause(err) == context.Canceled {
+				c.ResponseWriter().WriteHeader(0)
+				return
+			}
 			panic("session: load: " + err.Error())
 		}
 

--- a/session.go
+++ b/session.go
@@ -173,7 +173,7 @@ func Sessioner(opts ...Options) flamego.Handler {
 		sess, created, err := mgr.load(c.Request().Request, sid, opt.IDLength)
 		if err != nil {
 			if errors.Cause(err) == context.Canceled {
-				c.ResponseWriter().WriteHeader(0)
+				c.ResponseWriter().WriteHeader(http.StatusUnprocessableEntity)
 				return
 			}
 			panic("session: load: " + err.Error())


### PR DESCRIPTION
### Describe the pull request

I recently noticed the error `session: load: read: get: context canceled` in my sentry panel.

I traced the error into this package and found that it will panic when the user closes the connection.

Actually, there are some fixes applied in [line 188](https://github.com/flamego/session/blob/3a174aa4f5f885d873e71bc1bff66444ce19d38f/session.go#L188) but it is not enough.

Because the context canceled before the next handlers, I use `c.ResponseWriter().WriteHeader(0)` to end this handler chain.

By the way, I am looking forward flamego support the method like `Abort()` in gin to prevents pending handlers from being called.

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledged the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
