### PR TITLE
ci: run Go tests with `-shuffle=on`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
@@ -78,7 +78,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic ./postgres
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic ./postgres
         env:
           PGPORT: 5432
           PGHOST: localhost
@@ -116,7 +116,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic ./redis
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic ./redis
         env:
           REDIS_HOST: localhost
           REDIS_PORT: 6379
@@ -143,7 +143,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic ./mysql
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic ./mysql
         env:
           MYSQL_USER: root
           MYSQL_PASSWORD: root
@@ -183,7 +183,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic ./mongo
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic ./mongo
         env:
           MONGODB_URI: mongodb://root:password@localhost:27017
       - name: Upload coverage report to Codecov

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.18.x, 1.19.x ]
-        platform: [ ubuntu-18.04 ]
+        platform: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Start MySQL server


### PR DESCRIPTION
Updates CI to run Go tests with `-shuffle=on`

[_Created by Sourcegraph batch change `unknwon/run-go-tests-with-shuffle`._](https://cs.unknwon.dev/users/unknwon/batch-changes/run-go-tests-with-shuffle)