### PR TITLE
feat: only "touch" the session if no value updated

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [ 1.19.x, 1.20.x ]
+        go-version: [ 1.20.x, 1.21.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -55,7 +55,7 @@ jobs:
     name: Postgres
     strategy:
       matrix:
-        go-version: [ 1.19.x, 1.20.x ]
+        go-version: [ 1.20.x, 1.21.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     services:
@@ -95,7 +95,7 @@ jobs:
     name: Redis
     strategy:
       matrix:
-        go-version: [ 1.19.x, 1.20.x ]
+        go-version: [ 1.20.x, 1.21.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     services:
@@ -130,7 +130,7 @@ jobs:
     name: MySQL
     strategy:
       matrix:
-        go-version: [ 1.19.x, 1.20.x ]
+        go-version: [ 1.20.x, 1.21.x ]
         platform: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -159,7 +159,7 @@ jobs:
     name: Mongo
     strategy:
       matrix:
-        go-version: [ 1.19.x, 1.20.x ]
+        go-version: [ 1.20.x, 1.21.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     services:
@@ -196,7 +196,7 @@ jobs:
     name: SQLite
     strategy:
       matrix:
-        go-version: [ 1.20.x ]
+        go-version: [ 1.20.x, 1.21.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'flamego/session'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Generate LSIF data
         uses: sourcegraph/lsif-go-action@master
       - name: Upload LSIF data to sourcegraph.com

--- a/manager.go
+++ b/manager.go
@@ -24,6 +24,9 @@ type Store interface {
 	Read(ctx context.Context, sid string) (Session, error)
 	// Destroy deletes session with given ID from the session store completely.
 	Destroy(ctx context.Context, sid string) error
+	// Touch updates the expiry time of the session with given ID. It does nothing
+	// if there is no session associated with the ID.
+	Touch(ctx context.Context, sid string) error
 	// Save persists session data to the session store.
 	Save(ctx context.Context, session Session) error
 	// GC performs a GC operation on the session store.

--- a/manager_test.go
+++ b/manager_test.go
@@ -10,12 +10,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsValidSessionID(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		s, err := randomChars(16)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		assert.True(t, isValidSessionID(s, 16))
 	}
 

--- a/memory.go
+++ b/memory.go
@@ -155,9 +155,21 @@ func (s *memoryStore) Destroy(_ context.Context, sid string) error {
 	return nil
 }
 
-func (s *memoryStore) Save(context.Context, Session) error {
+func (s *memoryStore) Touch(_ context.Context, sid string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	sess, ok := s.index[sid]
+	if !ok {
+		return nil
+	}
+
+	sess.SetLastAccessedAt(s.nowFunc())
+	heap.Fix(s, sess.index)
 	return nil
 }
+
+func (s *memoryStore) Save(context.Context, Session) error { return nil }
 
 func (s *memoryStore) GC(ctx context.Context) error {
 	// Removing expired sessions from top of the heap until there is no more expired

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -89,6 +89,20 @@ func (s *mongoStore) Destroy(ctx context.Context, sid string) error {
 	return nil
 }
 
+func (s *mongoStore) Touch(ctx context.Context, sid string) error {
+	_, err := s.db.Collection(s.collection).
+		UpdateOne(ctx,
+			bson.M{"key": sid},
+			bson.M{"$set": bson.M{
+				"expired_at": s.nowFunc().Add(s.lifetime).UTC(),
+			}},
+		)
+	if err != nil {
+		return errors.Wrap(err, "update")
+	}
+	return nil
+}
+
 func (s *mongoStore) Save(ctx context.Context, sess session.Session) error {
 	binary, err := sess.Encode()
 	if err != nil {

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -95,6 +95,18 @@ func (s *mysqlStore) Destroy(ctx context.Context, sid string) error {
 	return err
 }
 
+func (s *mysqlStore) Touch(ctx context.Context, sid string) error {
+	q := fmt.Sprintf(`UPDATE %s SET expired_at = ? WHERE %s = ?`,
+		quoteWithBackticks(s.table),
+		quoteWithBackticks("key"),
+	)
+	_, err := s.db.ExecContext(ctx, q, s.nowFunc().Add(s.lifetime).UTC(), sid)
+	if err != nil {
+		return errors.Wrap(err, "update")
+	}
+	return nil
+}
+
 func (s *mysqlStore) Save(ctx context.Context, sess session.Session) error {
 	binary, err := sess.Encode()
 	if err != nil {

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -15,10 +15,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flamego/flamego"
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/flamego/flamego"
 	"github.com/flamego/session"
 )
 
@@ -127,7 +128,7 @@ func TestMySQLStore(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/set", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	f.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusOK, resp.Code)
@@ -136,7 +137,7 @@ func TestMySQLStore(t *testing.T) {
 
 	resp = httptest.NewRecorder()
 	req, err = http.NewRequest("GET", "/get", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	req.Header.Set("Cookie", cookie)
 	f.ServeHTTP(resp, req)
@@ -144,7 +145,7 @@ func TestMySQLStore(t *testing.T) {
 
 	resp = httptest.NewRecorder()
 	req, err = http.NewRequest("GET", "/destroy", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	req.Header.Set("Cookie", cookie)
 	f.ServeHTTP(resp, req)
@@ -167,42 +168,75 @@ func TestMySQLStore_GC(t *testing.T) {
 			InitTable: true,
 		},
 	)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	now = now.Add(3 * time.Second)
 	sess1, err := store.Read(ctx, "1")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = store.Save(ctx, sess1)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	now = now.Add(-3 * time.Second)
 
 	now = now.Add(-2 * time.Second)
 	sess2, err := store.Read(ctx, "2")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	sess2.Set("name", "flamego")
 	err = store.Save(ctx, sess2)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// Read on an expired session should wipe data but preserve the record.
 	// NOTE: MySQL is behaving flaky on exact the seconds, so let's wait one more
 	//  second.
 	now = now.Add(3 * time.Second)
 	tmp, err := store.Read(ctx, "2")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Nil(t, tmp.Get("name"))
 
 	now = now.Add(-2 * time.Second)
 	sess3, err := store.Read(ctx, "3")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = store.Save(ctx, sess3)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	now = now.Add(3 * time.Second)
 	err = store.GC(ctx) // sess3 should be recycled
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	assert.True(t, store.Exist(ctx, "1"))
 	assert.False(t, store.Exist(ctx, "2"))
 	assert.False(t, store.Exist(ctx, "3"))
+}
+
+func TestMySQLStore_Touch(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup := newTestDB(t, ctx)
+	t.Cleanup(func() {
+		assert.Nil(t, cleanup())
+	})
+
+	now := time.Now()
+	store, err := Initer()(ctx,
+		Config{
+			nowFunc:   func() time.Time { return now },
+			db:        db,
+			Lifetime:  time.Second,
+			InitTable: true,
+		},
+	)
+	require.Nil(t, err)
+
+	sess, err := store.Read(ctx, "1")
+	require.Nil(t, err)
+	err = store.Save(ctx, sess)
+	require.Nil(t, err)
+
+	now = now.Add(2 * time.Second)
+	// Touch should keep the session alive
+	err = store.Touch(ctx, sess.ID())
+	require.Nil(t, err)
+
+	err = store.GC(ctx)
+	require.Nil(t, err)
+	assert.True(t, store.Exist(ctx, sess.ID()))
 }

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -81,6 +81,15 @@ func (s *postgresStore) Destroy(ctx context.Context, sid string) error {
 	return err
 }
 
+func (s *postgresStore) Touch(ctx context.Context, sid string) error {
+	q := fmt.Sprintf(`UPDATE %q SET expired_at = $1 WHERE key = $2`, s.table)
+	_, err := s.db.ExecContext(ctx, q, s.nowFunc().Add(s.lifetime).UTC(), sid)
+	if err != nil {
+		return errors.Wrap(err, "update")
+	}
+	return nil
+}
+
 func (s *postgresStore) Save(ctx context.Context, sess session.Session) error {
 	binary, err := sess.Encode()
 	if err != nil {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -63,6 +63,14 @@ func (s *redisStore) Destroy(ctx context.Context, sid string) error {
 	return s.client.Del(ctx, sid).Err()
 }
 
+func (s *redisStore) Touch(ctx context.Context, sid string) error {
+	err := s.client.Expire(ctx, sid, s.lifetime).Err()
+	if err != nil {
+		return errors.Wrap(err, "expire")
+	}
+	return nil
+}
+
 func (s *redisStore) Save(ctx context.Context, sess session.Session) error {
 	binary, err := sess.Encode()
 	if err != nil {

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -13,10 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flamego/flamego"
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/flamego/flamego"
 	"github.com/flamego/session"
 )
 
@@ -103,7 +104,7 @@ func TestRedisStore(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/set", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	f.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusOK, resp.Code)
@@ -112,7 +113,7 @@ func TestRedisStore(t *testing.T) {
 
 	resp = httptest.NewRecorder()
 	req, err = http.NewRequest("GET", "/get", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	req.Header.Set("Cookie", cookie)
 	f.ServeHTTP(resp, req)
@@ -120,7 +121,7 @@ func TestRedisStore(t *testing.T) {
 
 	resp = httptest.NewRecorder()
 	req, err = http.NewRequest("GET", "/destroy", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	req.Header.Set("Cookie", cookie)
 	f.ServeHTTP(resp, req)
@@ -140,12 +141,12 @@ func TestRedisStore_GC(t *testing.T) {
 			Lifetime: time.Second,
 		},
 	)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	sess1, err := store.Read(ctx, "1")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = store.Save(ctx, sess1)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// NOTE: Redis is behaving flaky on exact the seconds in CI, so let's wait 100ms
 	// more.
@@ -153,13 +154,45 @@ func TestRedisStore_GC(t *testing.T) {
 	assert.False(t, store.Exist(ctx, "1"))
 
 	sess2, err := store.Read(ctx, "2")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	sess2.Set("name", "flamego")
 	err = store.Save(ctx, sess2)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	tmp, err := store.Read(ctx, "2")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "flamego", tmp.Get("name"))
+}
+
+func TestRedisStore_Touch(t *testing.T) {
+	ctx := context.Background()
+	client, cleanup := newTestClient(t, ctx)
+	t.Cleanup(func() {
+		assert.Nil(t, cleanup())
+	})
+
+	store, err := Initer()(ctx,
+		Config{
+			client:   client,
+			Lifetime: time.Second,
+		},
+	)
+	require.Nil(t, err)
+
+	sess, err := store.Read(ctx, "1")
+	require.Nil(t, err)
+	err = store.Save(ctx, sess)
+	require.Nil(t, err)
+
+	time.Sleep(500 * time.Millisecond)
+	err = store.Touch(ctx, sess.ID())
+	require.Nil(t, err)
+
+	// NOTE: Redis is behaving flaky on exact the seconds in CI, so let's wait 100ms
+	// more.
+	time.Sleep(600 * time.Millisecond)
+	err = store.GC(ctx)
+	require.Nil(t, err)
+	assert.True(t, store.Exist(ctx, sess.ID()))
 }

--- a/session_test.go
+++ b/session_test.go
@@ -103,6 +103,10 @@ func (s *noopStore) Destroy(context.Context, string) error {
 	return nil
 }
 
+func (s *noopStore) Touch(context.Context, string) error {
+	return nil
+}
+
 func (s *noopStore) Save(ctx context.Context, _ Session) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "something went wrong")

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -81,6 +81,15 @@ func (s *sqliteStore) Destroy(ctx context.Context, sid string) error {
 	return err
 }
 
+func (s *sqliteStore) Touch(ctx context.Context, sid string) error {
+	q := fmt.Sprintf(`UPDATE %q SET expired_at = $1 WHERE key = $2`, s.table)
+	_, err := s.db.ExecContext(ctx, q, s.nowFunc().Add(s.lifetime).UTC().Format(time.DateTime), sid)
+	if err != nil {
+		return errors.Wrap(err, "update")
+	}
+	return nil
+}
+
 func (s *sqliteStore) Save(ctx context.Context, sess session.Session) error {
 	binary, err := sess.Encode()
 	if err != nil {

--- a/sqlite/sqlite_test.go
+++ b/sqlite/sqlite_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/flamego/flamego"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/flamego/session"
 )
@@ -104,7 +105,7 @@ func TestSQLiteStore(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/set", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	f.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusOK, resp.Code)
@@ -113,7 +114,7 @@ func TestSQLiteStore(t *testing.T) {
 
 	resp = httptest.NewRecorder()
 	req, err = http.NewRequest("GET", "/get", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	req.Header.Set("Cookie", cookie)
 	f.ServeHTTP(resp, req)
@@ -121,7 +122,7 @@ func TestSQLiteStore(t *testing.T) {
 
 	resp = httptest.NewRecorder()
 	req, err = http.NewRequest("GET", "/destroy", nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	req.Header.Set("Cookie", cookie)
 	f.ServeHTTP(resp, req)
@@ -144,40 +145,73 @@ func TestSQLiteStore_GC(t *testing.T) {
 			InitTable: true,
 		},
 	)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	now = now.Add(3 * time.Second)
 	sess1, err := store.Read(ctx, "1")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = store.Save(ctx, sess1)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	now = now.Add(-3 * time.Second)
 
 	now = now.Add(-2 * time.Second)
 	sess2, err := store.Read(ctx, "2")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	sess2.Set("name", "flamego")
 	err = store.Save(ctx, sess2)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// Read on an expired session should wipe data but preserve the record.
 	now = now.Add(2 * time.Second)
 	tmp, err := store.Read(ctx, "2")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Nil(t, tmp.Get("name"))
 
 	now = now.Add(-2 * time.Second)
 	sess3, err := store.Read(ctx, "3")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = store.Save(ctx, sess3)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	now = now.Add(3 * time.Second)
 	err = store.GC(ctx) // sess3 should be recycled
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	assert.True(t, store.Exist(ctx, "1"))
 	assert.False(t, store.Exist(ctx, "2"))
 	assert.False(t, store.Exist(ctx, "3"))
+}
+
+func TestSQLiteStore_Touch(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup := newTestDB(t, ctx)
+	t.Cleanup(func() {
+		assert.Nil(t, cleanup())
+	})
+
+	now := time.Now()
+	store, err := Initer()(ctx,
+		Config{
+			nowFunc:   func() time.Time { return now },
+			db:        db,
+			Lifetime:  time.Second,
+			InitTable: true,
+		},
+	)
+	require.Nil(t, err)
+
+	sess, err := store.Read(ctx, "1")
+	require.Nil(t, err)
+	err = store.Save(ctx, sess)
+	require.Nil(t, err)
+
+	now = now.Add(2 * time.Second)
+	// Touch should keep the session alive
+	err = store.Touch(ctx, sess.ID())
+	require.Nil(t, err)
+
+	err = store.GC(ctx)
+	require.Nil(t, err)
+	assert.True(t, store.Exist(ctx, sess.ID()))
 }


### PR DESCRIPTION
### Describe the pull request

A session update may be reverted if another request starts before and ends after the request that updates the session. Thus we only "touch" the session record if no value update is made.

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
